### PR TITLE
Use URIs for discovery, add relay support

### DIFF
--- a/types.go
+++ b/types.go
@@ -2,12 +2,18 @@
 
 package main
 
+// Cannot reuse discover type, as generating XDR fails.
+type relay struct {
+	address string
+	latency int32 // milliseconds
+}
+
 type address struct {
-	ip   []byte
-	port uint16
-	seen int64 // epoch seconds
+	address string
+	seen    int64 // epoch seconds
 }
 
 type addressList struct {
 	addresses []address
+	relays    []relay
 }


### PR DESCRIPTION
I guess this is for discussion/review now.

Two things I don't like.

1. The big SplitHostPort chunk in `update`. Not even sure it does the correct thing, and probably fails for portless addresses.
2. The fact that we always replace the relays, not sure what the behaviour should be here.